### PR TITLE
fix links, tweak content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 FsLab web site
 ==============
 
-This repository contains the source code for the [www.fslab.org](http://www.fslab.org) web site.
+This repository contains the source code for the [fslab.org](http://fslab.org) web site.
 The published HTML is in the `master` branch and the `source` branch contains the source code.
 The site is generated using F# Formatting and using FAKE. You can build it and open it locally using:
 

--- a/build.fsx
+++ b/build.fsx
@@ -26,7 +26,7 @@ open Suave.Http.Files
 // Global definitions
 // --------------------------------------------------------------------------------------
 
-let githubLink = "http://github.com/fslaborg/fslaborg.github.io"
+let githubLink = "http://github.com/fslaborg/fslab.org"
 let publishBranch = "master"
 let info =
   [ "project-name", "N/A"; "project-author", "N/A"; "project-summary", "N/A"; 

--- a/content/download/index.fsx
+++ b/content/download/index.fsx
@@ -21,7 +21,7 @@ Download a template
 
 The easiest way to get started is to copy one of the templates that are
 from the [FsLab templates](http://github.com/fslaborg/FsLab.Templates)
-repository. The templates work with Xamarin Studio, Visual Studio and other
+repository. The templates work with Visual Studio Code, Visual Studio and other
 F# editors.
 
 <div style="margin:25px 0px 45px 15px">

--- a/content/index.md
+++ b/content/index.md
@@ -12,14 +12,14 @@
     <div class="carousel-inner" role="listbox">
       <div class="item active">
         <div class="container">
-          <h1>Data science tools <em>Professional, powerful &amp; cross-platform</em></h1>
+          <h1>Data science packages for F# <em>Powerful &amp; cross-platform</em></h1>
           <div class="row">
             <div class="col-sm-4 ta-right img-md" style="padding-left:0px;">
               <img src="img/carousel/cc.png" style="height:200px;margin-right:20px" />
             </div><div class="col-sm-8">
               <img src="img/carousel/cc.png" style="height:160px; float:left; margin:0px 10px 20px 0px;" class="img-xs" />
               <p>
-                FsLab is a collection of libraries for data-science. It provides a rapid development
+                FsLab is a collection of F# packages for data-science. They provide a rapid development
                 envi&shy;ronment that lets you write advanced analysis with a few lines of production-quality code.
               </p>
               <p>
@@ -37,12 +37,12 @@
       </div>
       <div class="item">
         <div class="container">
-          <h1>Increased productivity <em>Easy data access with R integration</em></h1>
+          <h1>Use what you know <em>Easy data access with R integration</em></h1>
           <div class="row">
             <div class="col-sm-5">
               <p>
-                Use <strong>F# Data type providers</strong> to access data from WorldBank, CSV files
-                and any other JSON or XML-based web services and cleanup data easily.
+                Use <strong>FSharp.Data type providers</strong> to access data from HTML, CSV files
+                and JSON and XML-based web services and cleanup data easily.
               </p>
               <p>
                 Use the <strong>R type provider</strong> to call any package from the R language
@@ -78,11 +78,11 @@
         <div class="container">
           <div class="row">
             <div class="col-sm-8">
-              <h1 style="margin-top:10px;">Production-ready <em>Create reports and deploy in production</em></h1>
+              <h1 style="margin-top:10px;">Reports and Documents <em>Create reports and deploy in production</em></h1>
               <img src="img/carousel/report.png" style="height:220px;margin-right:20px;float:left;" class="img-xs" />
               <p>
-                Data analysis using FsLab can be easily deployed into a cross-platform production
-                environment using Mono and .NET. It provides an environment comfortable for scientists,
+                Data analysis scripts using FsLab can be deployed into cross-platform production
+                environments. Markdown scripts provides an environment comfortable for scientists,
                 data analysts as well as developers.
               </p>
               <p>
@@ -116,7 +116,7 @@
         <h2><span><i class="fa fa-cubes"></i></span> Cross-platform</h2>
         <p>
           FsLab runs on Mac, Linux and Windows. You can use it with Emacs,
-          Xamarin Studio, MonoDevelop, Visual Studio or other F#-enabled editor.
+          Visual Studio Code, Visual Studio or any other F#-enabled editor.
         </p>
       </div>
       <div class="col-xs-12 col-md-4 col-sm-6">
@@ -151,7 +151,7 @@
         <h2><span><i class="fa fa-rocket"></i></span> Cloud-scale</h2>
         <p>
           F# code is type-inferred and efficiently compiled. It runs on multi-core and you can easily
-          scale to the cloud with <a href="http://www.mbrace.io/">MBrace</a>.
+          scale to the cloud with <a href="https://docs.microsoft.com/dotnet/fsharp/using-fsharp-on-azure/">Azure</a>.
         </p>
       </div>
     </div>
@@ -226,13 +226,13 @@
     </div>
     <div class="row components">
       <div class="col-md-6">
-        <h3><span><i class="fa fa-database"></i></span> F# Data <em>First-class data access</em></h3>
+        <h3><span><i class="fa fa-database"></i></span> FSharp.Data <em>First-class data access</em></h3>
         <ul>
           <li>Use language that understands external data sources</li>
-          <li>Access JSON, XML, CSV, HTML and WorldBank</li>
+          <li>Access JSON, XML, CSV and HTML</li>
           <li>Get auto-completion based on a sample document</li>
         </ul>
-        <a href="http://fsharp.github.io/FSharp.Data/" class="btn fst btn-primary" role="button">F# Data homepage</a>
+        <a href="http://fsharp.github.io/FSharp.Data/" class="btn fst btn-primary" role="button">FSharp.Data homepage</a>
       </div>
       <div class="col-md-6">
         <h3><span><i class="fa fa-bars"></i></span> Deedle <em>Interactive data exploration</em></h3>
@@ -241,8 +241,8 @@
           <li>Quickly explore data &amp; build efficient compiled code</li>
           <li>Automatic alignment, missing data handling &amp; more</li>
         </ul>
-        <a href="http://bluemountaincapital.github.io/Deedle/tutorial.html" class="btn fst btn-primary" role="button">Deedle in 10 minutes</a>
-        <a href="http://bluemountaincapital.github.io/Deedle/" class="btn btn-primary" role="button">Homepage</a>
+        <a href="http://fslab.org/Deedle/tutorial.html" class="btn fst btn-primary" role="button">Deedle in 10 minutes</a>
+        <a href="http://fslab.org/Deedle/" class="btn btn-primary" role="button">Homepage</a>
       </div>
     </div>
     <div class="row components">
@@ -253,7 +253,7 @@
           <li>Pass data frames and time-series to R easily</li>
           <li>Get auto-completion on R functions &amp; parameters</li>
         </ul>
-        <a href="http://bluemountaincapital.github.io/FSharpRProvider" class="btn fst btn-primary" role="button">R provider homepage</a>
+        <a href="http://fslab.org/RProvider" class="btn fst btn-primary" role="button">R provider homepage</a>
       </div>
       <div class="col-md-6">
         <h3><span><i class="fa fa-calculator"></i></span> Math.NET <em>Fast numerical calculations</em></h3>
@@ -315,11 +315,11 @@
       <div class="col-md-12">
         <a href="http://fsharp.github.io/FSharp.Data/"><img src="/img/logos/fsharpdata.png" /></a>
         <a href="https://fslab.org/XPlot/"><img src="/img/logos/xplot.png" /></a>
-        <a href="http://bluemountaincapital.github.io/Deedle/"><img src="/img/logos/deedle.png" /></a>
-        <a href="http://bluemountaincapital.github.io/FSharpRProvider"><img src="/img/logos/rprovider.png" /></a>
+        <a href="http://fslab.org/Deedle/"><img src="/img/logos/deedle.png" /></a>
+        <a href="http://fslab.org/RProvider"><img src="/img/logos/rprovider.png" /></a>
         <a href="http://numerics.mathdotnet.com"><img src="/img/logos/mathnet.png" /></a>
         <a href="https://fsprojects.github.io/FSharp.Formatting"><img src="/img/logos/fsformatting.png" /></a>
-        <a href="http://www.fslab.org"><img src="/img/logos/fslab.png" /></a>
+        <a href="http://fslab.org"><img src="/img/logos/fslab.png" /></a>
       </div>
     </div>
   </div>
@@ -334,7 +334,6 @@
           Training and support <em>Need help with FsLab?</em><a name="support">&nbsp;</a>
         </h2>
         <p>
-          Consultancy partners including
           <a href="http://fsharpworks.com/">fsharpWorks</a>
           contribute to FsLab and provide training, support and
           other services.
@@ -343,19 +342,12 @@
           <li>
             If you are using FsLab in finance, you can learn more about FsLab from the
             online course <a href="http://fsharpworks.com/workshops/finance.html">F# in Finance</a>,
-            which covers Deedle, F# Data and other components.
+            which covers Deedle, FSharp.Data and other components.
           </li>
           <li>The <a href="http://fsharpworks.com/workshops/fast-track.html">FastTrack to F#</a>
           course covers many of the FsLab components too and
           fsharpWorks also offer <a href="http://fsharpworks.com/workshops.html">custom workshops</a>.</li>
         </ul>
-        <p>
-          There are a large number of other companies that provide training and
-          consulting services related to F# that will be able to help with FsLab. See the
-          <a href="http://fsharp.org/training/">training page</a> and
-          <a href="http://fsharp.org/consulting/">consulting page</a> on the
-          F# Foundation web site.
-        </p>
       </div>
       <div class="col-md-5 img-holder">
         <a href="http://www.fsharpworks.com">

--- a/content/resources/index.md
+++ b/content/resources/index.md
@@ -10,7 +10,7 @@ about FsLab and the various libraries that are a part of the FsLab package.
  * [Videos and conference talks](#Videos-and-conference-talks) including Strata, NDC and Øredev
  * [Blog posts and articles](#Blog-posts-and-articles) about FsLab, XPlot, Deedle and more
 
-If you did a talk or wrote an article yourself, send us [a pull request and add it](https://github.com/fslaborg/fslaborg.github.io/blob/source/content/resources/index.md)
+If you did a talk or wrote an article yourself, send us [a pull request and add it](https://github.com/fslaborg/fslab.org/blob/source/content/resources/index.md)
 to the list! 
 
 ***************************************************************************************************
@@ -27,7 +27,7 @@ _Tomas Petricek, O'Reilly, 2015_
 This report explains many of the key features of the F# language that make it a great tool 
 for data science and machine learning. Real world examples take you through the entire data 
 science workflow with F#, from data access and analysis to presenting the results. You'll learn about
-F# Data and type providers, the process of data analysis with Deedle and R type provider and
+FSharp.Data and type providers, the process of data analysis with Deedle and R type provider and
 the implementation of basic machine learning algorithm with F#.
 
 ### Machine Learning Projects for .NET Developers
@@ -79,7 +79,7 @@ Here are some of the best talks that have been recorded.
    This lecture shows how to access JSON, CSV and World Bank data, combine and analyze the data and visualize the results.
 
  - [**F# and Machine Learning: a winning combination**](https://vimeo.com/97514517) (NDC)<br />
-   Introduction to machine learning with F# and FsLab libraries such as F# Data type providers for easy data access.
+   Introduction to machine learning with F# and FsLab libraries such as FSharp.Data type providers for easy data access.
       
  - [**Mona Lisa, F# and Azure: simple solutions to hard problems**](https://vimeo.com/113597999) (NDC)<br />
    In this talk, we will explore one of the latter, the Mona Lisa Travelling Salesman Problem, and how we used modern tools to tackle it
@@ -97,7 +97,7 @@ Blog posts and articles
 -----------------------
 
 There is an amazing number of great (and also fun) articles and blog posts that demonstrate the power of FsLab.
-If you wrote an article yourself, send us [a pull request and add it](https://github.com/fslaborg/fslaborg.github.io/blob/source/content/resources/index.md)! 
+If you wrote an article yourself, send us [a pull request and add it](https://github.com/fslaborg/fslab.org/blob/source/content/resources/index.md)! 
 
 ### Editor's picks
 

--- a/templates/rightpanel.html
+++ b/templates/rightpanel.html
@@ -1,10 +1,10 @@
-<a href="www.fslab.org">
+<a href="fslab.org">
   <img src="/img/logos/fslab.png" id="logo" />
 </a>
 
 <ul class="nav nav-list" id="menu">
   <li class="nav-header">FsLab</li>
-  <li><a href="http://www.fslab.org">Home page</a></li>
+  <li><a href="http://fslab.org">Home page</a></li>
   <li><a href="https://nuget.org/packages/FsLab">Get FsLab via NuGet</a></li>
   <li><a href="http://github.com/fslaborg">FsLab on GitHub</a></li>
   <li><a href="https://twitter.com/fslaborg">Follow us on Twitter</a></li>
@@ -16,10 +16,10 @@
   <li><a href="http://www.apress.com/9781430267676" class="external">Machine Learning Projects for .NET Developers</a></li>
 
   <li class="nav-header">Documentation</li>
-  <li><a href="http://fsharp.github.io/FSharp.Data/" class="external">F# Data</a></li>
-  <li><a href="http://bluemountaincapital.github.io/Deedle/" class="external">Deedle</a></li>
-  <li><a href="http://bluemountaincapital.github.io/FSharpRProvider/" class="external">R Type Provider</a></li>
+  <li><a href="http://fsharp.github.io/FSharp.Data/" class="external">FSharp.Data</a></li>
+  <li><a href="http://fslab.org/Deedle/" class="external">Deedle</a></li>
+  <li><a href="http://fslab.org/RProvider/" class="external">R Type Provider</a></li>
   <li><a href="http://numerics.mathdotnet.com/" class="external">Math.NET Numerics</a></li>
   <li><a href="https://fslab.org/XPlot/" class="external">XPlot Visualization</a></li>
-  <li><a href="http://fsharp.github.io/FSharp.Charting/" class="external">F# Charting</a></li>
+  <li><a href="http://fslab.org/FSharp.Charting/" class="external">F# Charting</a></li>
 </ul>

--- a/templates/template.cshtml
+++ b/templates/template.cshtml
@@ -112,10 +112,9 @@
         <div class="col-md-4">
           <h3>About the F# language</h3>
           <img src="/img/logos/fsharp.png" style="float:right;margin:0px 0px 20px 20px">
-          <p>We love the foundation and we think you might too!</p>
           <ul>
-            <li>Visit <a href="http://fsharp.org">F# web site</a> for more info</li>
-            <li><a href="http://foundation.fsharp.org">Join and help</a> the foundation</li>
+            <li>Visit <a href="http://fsharp.org">fsharp.org</a> for more info</li>
+            <li><a href="http://foundation.fsharp.org">Join and help</a> the F# Software Foundation</li>
           </ul>
         </div>
       </div>

--- a/templates/template.cshtml
+++ b/templates/template.cshtml
@@ -64,12 +64,12 @@
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation <span class="caret"></span></a>
             <ul class="dropdown-menu" role="menu">
-              <li><a href="http://fsharp.github.io/FSharp.Data/" class="external">F# Data</a></li>
-              <li><a href="http://bluemountaincapital.github.io/Deedle/" class="external">Deedle</a></li>
-              <li><a href="http://bluemountaincapital.github.io/FSharpRProvider/" class="external">R Type Provider</a></li>
+              <li><a href="http://fsharp.github.io/FSharp.Data/" class="external">FSharp.Data</a></li>
+              <li><a href="http://fslab.org/Deedle/" class="external">Deedle</a></li>
+              <li><a href="http://fslab.org/RProvider/" class="external">R Type Provider</a></li>
               <li><a href="http://numerics.mathdotnet.com/" class="external">Math.NET Numerics</a></li>
               <li><a href="http://fslab.org/XPlot/" class="external">XPlot Visualization</a></li>
-              <li><a href="http://fsharp.github.io/FSharp.Charting/" class="external">F# Charting</a></li>
+              <li><a href="http://fslab.org/FSharp.Charting/" class="external">F# Charting</a></li>
             </ul>
           </li>
           <li><a href="/#support">Training &amp; support</a></li>
@@ -86,12 +86,11 @@
         <div class="col-md-4">
           <h3>About FsLab</h3>
           <p>
-            FsLab is a collection of popular F# open-source libraries for data science
-            maintained by <a href="http://twitter.com/tomaspetricek">@@tomaspetricek</a> &amp; contributors.
+            FsLab is a collection of popular F# open-source libraries for data science.
           </p>
           <ul>
             <li>Follow <a href="http://twitter.com/fslaborg">@@fslaborg</a> for updates</li>
-            <li>Report issues on <a href="http://github.com/tpetricek/FsLab">GitHub</a></li>
+            <li>Report issues on <a href="http://github.com/fslaborg/FsLab">GitHub</a></li>
           </ul>
           <h3>Support</h3>
           <p>
@@ -102,23 +101,17 @@
         </div>
         <div class="col-md-4">
           <h3>FsLab contributors</h3>
-          <p>Component authors include leading F# contributors:</p>
+          <p>Component maintainers include leading F# contributors:</p>
           <ul>
             <li>Tomas Petricek | <a href="http://twitter.com/tomaspetricek">@@tomaspetricek</a></li>
             <li>Gustavo Guerra | <a href="http://twitter.com/ovatsus">@@ovatsus</a></li>
             <li>Christoph Ruegg | <a href="http://twitter.com/cdrnet">@@cdrnet</a></li>
-            <li>F# Works | <a href="http://twitter.com/fsharpworks">@@fsharpworks</a></li>
-            <li>BlueMountain Capital</li>
           </ul>
           <p>...and many others. For a complete list, check out the contributors of individual FsLab libraries.</p>
         </div>
         <div class="col-md-4">
           <h3>About the F# language</h3>
           <img src="/img/logos/fsharp.png" style="float:right;margin:0px 0px 20px 20px">
-          <p>
-            FsLab is built using the F# language, but
-            it is not affiliated to the F# Software Foundation.
-          </p>
           <p>We love the foundation and we think you might too!</p>
           <ul>
             <li>Visit <a href="http://fsharp.org">F# web site</a> for more info</li>


### PR DESCRIPTION
This fixes links https://github.com/fslaborg/FsLab/issues/136 and tweaks the content a little to focus more on FsLab being a collection of packages for data science with F#.

